### PR TITLE
allow all data to load to bq

### DIFF
--- a/mod-4-analytics-engineering/ny-taxi-rides/models/staging/stg_green_tripdata.sql
+++ b/mod-4-analytics-engineering/ny-taxi-rides/models/staging/stg_green_tripdata.sql
@@ -45,8 +45,8 @@ where rn = 1
 
 
 -- dbt build --select <model_name> --vars '{'is_test_run': 'false'}'
-{% if var('is_test_run', default=true) %}
+-- {% if var('is_test_run', default=true) %}
 
-  limit 100
+--   limit 100
 
-{% endif %}
+-- {% endif %}

--- a/mod-4-analytics-engineering/ny-taxi-rides/models/staging/stg_yellow_tripdata.sql
+++ b/mod-4-analytics-engineering/ny-taxi-rides/models/staging/stg_yellow_tripdata.sql
@@ -41,8 +41,8 @@ from tripdata
 where rn = 1
 
 -- dbt build --select <model.sql> --vars '{'is_test_run: false}'
-{% if var('is_test_run', default=true) %}
+-- {% if var('is_test_run', default=true) %}
 
-  limit 100
+--   limit 100
 
-{% endif %}
+-- {% endif %}


### PR DESCRIPTION
changed code so that all green and yellow taxi data will load to bq. Before we limited only 200 records.